### PR TITLE
Update repository link

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@ for your device asap.</p>
 <h2>
 <a id="downloads" class="anchor" href="#downloads" aria-hidden="true"><span class="octicon octicon-link"></span></a>Downloads</h2>
 
-<p><a href="https://github.com/linuxxxxx/vendor_google/releases">https://github.com/linuxxxxx/vendor_google/releases</a></p>
+<p><a href="https://github.com/cgapps/vendor_google/releases">https://github.com/cgapps/vendor_google/releases</a></p>
 
 <h2>
 <a id="build" class="anchor" href="#build" aria-hidden="true"><span class="octicon octicon-link"></span></a>Build</h2>


### PR DESCRIPTION
linuxxxxx/vendor_google isn't a valid repo anymore.
This updates the links to point to [cgapps/vendor_google](https://github.com/cgapps/vendor_google) instead.
